### PR TITLE
Docker defines images and builds for mainline and Galaxy releases (similar to CSP2)

### DIFF
--- a/hooks/pre_gen_project.sh
+++ b/hooks/pre_gen_project.sh
@@ -5,7 +5,7 @@ PKG_NAME='{{cookiecutter.pkg_name}}'
 
 {% if cookiecutter.__name_check %}
 # Query PyPI to check if the project exists
-response=$(curl -s -o /dev/null -w "%{http_code}" https://pypi.org/project/$PKG_NAME/)
+response=$(curl -s -o /dev/null -w "%{http_code}" https://pypi.org/pypi/$PKG_NAME/json)
 
 if [ "$response" -eq 200 ]; then
     echo "Project '$PKG_NAME' exists on PyPI."

--- a/{{cookiecutter.__project_slug}}/.github/workflows/build_{{cookiecutter.__project_slug}}_docker.yml
+++ b/{{cookiecutter.__project_slug}}/.github/workflows/build_{{cookiecutter.__project_slug}}_docker.yml
@@ -1,12 +1,10 @@
 name: Build {{cookiecutter.__project_slug}} Docker Image
 
 on:
-  push:
-    branches:
-        - main
-        - master
+  release:
+    types: [published]
 
-{%- raw -%}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -20,17 +18,31 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
+      - {% raw %}
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
+      - {% endraw %}
         name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: user/app:latest
-{%- endraw -%}
+          target: runtime
+          tags: {{ cookiecutter.github_username}}/{{ cookiecutter.__project_slug }}:latest,{{ cookiecutter.github_username}}/{{ cookiecutter.__project_slug }}:{% raw %}${{ github.ref_name }}{% endraw %}
+          {% raw %} build-args: |
+            VERSION=${{ github.ref_name }}
+          {%- endraw -%}
+      -
+        name: Build for Galaxy
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          target: galaxy
+          tags: {{ cookiecutter.github_username}}/{{ cookiecutter.__project_slug }}:galaxy,{{ cookiecutter.github_username}}/{{ cookiecutter.__project_slug }}:{% raw %}${{ github.ref_name }}-galaxy{% endraw %}
+          {% raw %} build-args: |
+            VERSION=${{ github.ref_name }}
+          {%- endraw -%}

--- a/{{cookiecutter.__project_slug}}/Dockerfile
+++ b/{{cookiecutter.__project_slug}}/Dockerfile
@@ -1,3 +1,5 @@
+ARG VERSION={{ cookiecutter.version}}
+
 # The build-stage image:
 FROM continuumio/miniconda3 AS build
 
@@ -28,9 +30,17 @@ LABEL maintainer="{{cookiecutter.email}}"
 # Copy /venv from the previous stage:
 COPY --from=build /venv /venv
 {%- if cookiecutter.project_shell_cmd %}
+
 # When image is run, run the code with the environment
 # activated:
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT source /venv/bin/activate && \
            {{cookiecutter.project_shell_cmd}})"
 {%- endif %}
+
+FROM runtime AS galaxy
+
+# For use in Galaxy we need an entrypoint that drops us
+# into Bash
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/bin/bash"]

--- a/{{cookiecutter.__project_slug}}/Makefile
+++ b/{{cookiecutter.__project_slug}}/Makefile
@@ -89,4 +89,7 @@ dev: clean install-test ## install the dev and test dependencies and install in 
 	python -m pip install -e .[dev]
 
 container: ## create the latest version of the container image
-	docker build -t {{cookiecutter.github_username}}/{{ cookiecutter.__project_slug }}:latest .
+	docker build --build-arg VERSION=$( git describe ) -t {{cookiecutter.github_username}}/{{ cookiecutter.__project_slug }}:latest .
+
+
+


### PR DESCRIPTION
Project now defines a Dockerfile and Github action that build on release for the regular, versioned, mainline ("latest") release, releases under the release version tag for pinning by users, and now builds a specific container that's more useful for Galaxy as both a "galaxy" release (like "latest") and a release-tagged release.